### PR TITLE
Complete Bun migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
+  - package-ecosystem: "bun"
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version-file: package.json
       - name: Install dependencies
         run: bun ci
       - name: Run tests

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version-file: package.json
 
       - name: Setup Expo
         uses: expo/expo-github-action@v8


### PR DESCRIPTION
## Summary

- switch Dependabot from npm to Bun so dependency PRs update `bun.lock`
- use `package.json` as the Bun version source in both GitHub Actions workflows

## Why

PR #220 migrated installs, scripts, and the lockfile to Bun. Dependabot still targeted npm, and CI duplicated the Bun version.

## Validation

- `bun ci`
- `bun run test:ci` (11 suites passed, 65 tests passed, 2 suites skipped)
- `bun run type-check`
- GitHub workflow YAML parsed successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management to use Bun.
  * CI workflows now use the Bun version specified by the project configuration, keeping development and automation environments aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->