### PR TITLE
docs: require conventional commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository conventions
+
+## Commits
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for every commit.
+- Format descriptions as `<type>[optional scope]: <description>`.
+- Use `feat` for features and `fix` for bug fixes. Use `build`, `chore`, `ci`, `docs`, `refactor`, `style`, or `test` when they fit.
+- Mark breaking changes with `!` before `:` or a `BREAKING CHANGE:` footer.


### PR DESCRIPTION
## Summary

- add root `AGENTS.md`
- require Conventional Commits
- document format, common types, and breaking-change syntax

## Why

Consistent commit metadata makes history easier to scan and keeps release automation predictable.

## Validation

- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance covering Conventional Commits, supported commit types, and breaking-change notation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->