### PR TITLE
ci: deploy Release Please builds to TestFlight

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 15
     concurrency:
       group: testflight
       cancel-in-progress: false
@@ -68,4 +68,5 @@ jobs:
           --profile production
           --auto-submit
           --non-interactive
+          --no-wait
           --freeze-credentials

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,6 +29,12 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: testflight
+      cancel-in-progress: false
+    permissions:
+      contents: read
     steps:
       - name: Checkout released commit
         uses: actions/checkout@v4
@@ -48,7 +54,7 @@ jobs:
       - name: Set up Expo and EAS
         uses: expo/expo-github-action@v8
         with:
-          eas-version: latest
+          eas-version: 21.4.0
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Install dependencies

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
       release_sha: ${{ steps.release.outputs.sha }}
     steps:
       - id: release
-        uses: google-github-actions/release-please-action@v3
+        uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3.7.13
         with:
           release-type: expo
           package-name: release-please-action
@@ -37,22 +37,23 @@ jobs:
       contents: read
     steps:
       - name: Checkout released commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ needs.release-please.outputs.release_sha }}
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .node-version
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: package.json
 
       - name: Set up Expo and EAS
-        uses: expo/expo-github-action@v8
+        uses: expo/expo-github-action@c7b66a9c327a43a8fa7c0158e7f30d6040d2481e # 8.2.1
         with:
           eas-version: 21.4.0
           token: ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,13 +3,62 @@ on:
     branches:
       - main
 name: release-please
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      release_sha: ${{ steps.release.outputs.sha }}
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - id: release
+        uses: google-github-actions/release-please-action@v3
         with:
           release-type: expo
           package-name: release-please-action
           bootstrap-sha: 880ad4c4d939d3e62d24cbeeaf7e864405727fe6
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false},{"type":"refactor","section":"Refactors","hidden":false},{"type":"style","section":"Styling","hidden":false},{"type":"docs","section":"Documentation","hidden":false}]'
+
+  testflight:
+    name: Build and submit to TestFlight
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout released commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.release_sha }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Set up Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: bun ci
+
+      - name: Build and submit iOS release
+        run: >-
+          eas build
+          --platform ios
+          --profile production
+          --auto-submit
+          --non-interactive
+          --freeze-credentials

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,7 @@
 
 ## Public repository security
 
-- This project is public open source. Treat every tracked file, commit, branch, pull request, issue, comment, workflow log, and artifact as public.
-- Never include credentials or secret values in code, configuration, documentation, examples, commits, pull request titles or descriptions, issues, comments, logs, or artifacts.
-- This includes passwords, API keys, access tokens, private keys, signing certificates, provisioning data, session values, cookies, two-factor codes, and personal data.
-- Reference secret names only. Store values in an approved secret manager, GitHub Actions secrets, or EAS-managed credentials.
-- Inspect staged changes and pull request text for accidental secret exposure before publishing.
-- If exposure is suspected, stop publishing and rotate the credential. Removing it from a later commit is not sufficient.
+- This project is public open source, so never include credentials or secret values in code, configuration, documentation, commits, pull requests, issues, comments, logs, or artifacts; reference secret names only and store values in approved secret managers.
 
 ## Commits
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # Repository conventions
 
+## Public repository security
+
+- This project is public open source. Treat every tracked file, commit, branch, pull request, issue, comment, workflow log, and artifact as public.
+- Never include credentials or secret values in code, configuration, documentation, examples, commits, pull request titles or descriptions, issues, comments, logs, or artifacts.
+- This includes passwords, API keys, access tokens, private keys, signing certificates, provisioning data, session values, cookies, two-factor codes, and personal data.
+- Reference secret names only. Store values in an approved secret manager, GitHub Actions secrets, or EAS-managed credentials.
+- Inspect staged changes and pull request text for accidental secret exposure before publishing.
+- If exposure is suspected, stop publishing and rotate the credential. Removing it from a later commit is not sufficient.
+
 ## Commits
 
 - Use [Conventional Commits](https://www.conventionalcommits.org/) for every commit.

--- a/README.md
+++ b/README.md
@@ -76,17 +76,9 @@ $ bun start
 
 ## Releasing
 
-### Preview
+Merging a Release Please PR creates the GitHub release, builds the production iOS app with EAS, and submits it to TestFlight. TestFlight submission does not release the app publicly. Promote the tested build manually in App Store Connect.
 
-1. (If native changes) `bun run publish:preview` (iOS and Android builds are built and submited for testing)
-2. Merge a PR to `preview` branch (automatically publishing a release to all betatesters)
-
-### Production
-
-1. (If native changes) `bun run publish:production` (iOS and Android builds are built and submited for testing)
-2. (If native changes) Submit App to Review in Google Play Console
-3. (If native changes) Submit App to Review in App Store Connect
-4. Merge a PR to `production` branch (automatically publishing a release to all users)
+See [TestFlight release workflow](./docs/testflight-release-workflow.md) for prerequisites, operation, and verification criteria.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Merging a Release Please PR creates the GitHub release, builds the production iO
 
 See [TestFlight release workflow](./docs/testflight-release-workflow.md) for prerequisites, operation, and verification criteria.
 
+Android store submissions remain manual. JavaScript and asset updates pushed to `preview` or `production` continue through the [EAS Update workflow](./.github/workflows/update.yml) when compatible with the installed runtime.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Merging a Release Please PR creates the GitHub release, builds the production iO
 
 See [TestFlight release workflow](./docs/testflight-release-workflow.md) for prerequisites, operation, and verification criteria.
 
-Android store submissions remain manual. JavaScript and asset updates pushed to `preview` or `production` continue through the [EAS Update workflow](./.github/workflows/update.yml) when compatible with the installed runtime.
+Android store submissions remain manual: run `bun run build:android:prod`, then `bunx eas-cli submit --platform android --path <path-to-aab>`. JavaScript and asset updates pushed to `preview` or `production` continue through the [EAS Update workflow](./.github/workflows/update.yml) when compatible with the installed runtime.
 
 ## Contributing
 

--- a/docs/testflight-release-workflow.md
+++ b/docs/testflight-release-workflow.md
@@ -64,7 +64,9 @@ Submission stops at TestFlight. Releasing the build publicly still requires manu
 - Missing or invalid App Store Connect credentials fail the submission after a successful build.
 - Build or submission failure is visible from the EAS build/submission linked by GitHub Actions.
 - Retry a failed submission without rebuilding: `eas submit --platform ios --profile production --id <BUILD_ID>`.
-- Retrying a failed build creates a new remote build number and does not collide with an earlier upload.
+- Retry a failed build with GitHub's **Re-run failed jobs**, which preserves the Release Please outputs; **Re-run all jobs** skips TestFlight because the GitHub release already exists.
+- If the original GitHub run is unavailable, retry from the released commit with `eas build --platform ios --profile production --auto-submit --non-interactive --freeze-credentials`.
+- A retried build creates a new remote build number and does not collide with an earlier upload.
 
 ## Rollback
 

--- a/docs/testflight-release-workflow.md
+++ b/docs/testflight-release-workflow.md
@@ -23,7 +23,7 @@ Submission stops at TestFlight. Releasing the build publicly still requires manu
 3. Merge the Release Please PR.
 4. Release Please creates a GitHub release and reports `release_created=true`.
 5. GitHub Actions checks out the released commit and starts an EAS production build.
-6. EAS signs the app, increments its build number, and submits the successful build to TestFlight.
+6. GitHub Actions exits after EAS accepts the build; EAS continues remotely, signs the app, increments its build number, and submits the successful build to TestFlight.
 7. Verify tester distribution in App Store Connect.
 8. After testing, manually promote that same build for App Review when ready.
 

--- a/docs/testflight-release-workflow.md
+++ b/docs/testflight-release-workflow.md
@@ -1,0 +1,68 @@
+# TestFlight release workflow
+
+## Outcome
+
+Merging a Release Please PR uploads the exact released commit to TestFlight. Normal pushes to `main` do not create builds.
+
+EAS uses the `production` build and submission profiles. Build numbers are stored and incremented remotely, preventing duplicate App Store Connect uploads when a build must be retried.
+
+Submission stops at TestFlight. Releasing the build publicly still requires manual promotion and App Review in App Store Connect.
+
+## Prerequisites
+
+- GitHub Actions secret `EXPO_TOKEN` authenticates an Expo account with access to EAS project `8917be91-f1cc-4276-a252-674a28490ac3`.
+- EAS has valid Apple distribution credentials for team `8VVNC4724B` and bundle identifier `com.devmood.pixymoodtracker`.
+- EAS Submit has a valid App Store Connect API key for app `1605327124`.
+- Remote iOS build version is initialized above the highest build number already uploaded to App Store Connect.
+- Internal testers belong to an automatically distributed TestFlight group. External testers have completed Apple's required Beta App Review.
+
+## Release
+
+1. Merge product changes into `main` using Conventional Commit messages.
+2. Review the Release Please PR version and changelog.
+3. Merge the Release Please PR.
+4. Release Please creates a GitHub release and reports `release_created=true`.
+5. GitHub Actions checks out the released commit and starts an EAS production build.
+6. EAS signs the app, increments its build number, and submits the successful build to TestFlight.
+7. Verify tester distribution in App Store Connect.
+8. After testing, manually promote that same build for App Review when ready.
+
+## Verification criteria
+
+### Before merging this workflow
+
+- `eas.json` parses as JSON.
+- Expo resolves bundle identifier `com.devmood.pixymoodtracker`, EAS project ID `8917be91-f1cc-4276-a252-674a28490ac3`, and App Store Connect app ID `1605327124`.
+- Production profile uses remote versioning and automatic build-number increments.
+- Test and type-check workflows pass.
+- GitHub Actions secret `EXPO_TOKEN` exists.
+- EAS iOS distribution and App Store Connect credentials are valid.
+
+### Dry-path behavior
+
+- A normal push to `main` runs Release Please.
+- When no GitHub release is created, `testflight` is shown as skipped.
+- No EAS build is created for that push.
+
+### Release behavior
+
+- Merging a Release Please PR creates one GitHub release and tag.
+- `testflight` starts only after `release-please` succeeds.
+- Workflow checks out the SHA reported by Release Please, matching the GitHub release tag.
+- EAS creates one iOS build using the `production` profile.
+- Build number is greater than the previous App Store Connect build number.
+- Bundle identifier is `com.devmood.pixymoodtracker`.
+- Successful build is uploaded to app `1605327124` and appears under TestFlight after Apple processing.
+- Intended TestFlight users can install the build.
+- Build is not submitted for public App Review automatically.
+
+### Failure behavior
+
+- Missing or invalid Expo authentication fails before a build starts.
+- Missing, expired, or changed Apple credentials fail the build because CI uses `--freeze-credentials`; CI never replaces credentials silently.
+- Build or submission failure is visible from the EAS build/submission linked by GitHub Actions.
+- Retrying the release build uses a new remote build number and does not collide with an earlier upload.
+
+## Rollback
+
+Disable or remove the `testflight` job from `.github/workflows/release-please.yml`. Existing TestFlight and App Store builds remain unchanged. No public release happens automatically.

--- a/docs/testflight-release-workflow.md
+++ b/docs/testflight-release-workflow.md
@@ -13,7 +13,7 @@ Submission stops at TestFlight. Releasing the build publicly still requires manu
 - GitHub Actions secret `EXPO_TOKEN` authenticates an Expo account with access to EAS project `8917be91-f1cc-4276-a252-674a28490ac3`.
 - EAS has valid Apple distribution credentials for team `8VVNC4724B` and bundle identifier `com.devmood.pixymoodtracker`.
 - EAS Submit has a valid App Store Connect API key for app `1605327124`.
-- Remote iOS build version is initialized above the highest build number already uploaded to App Store Connect.
+- Remote iOS build number is initialized above the highest build already uploaded to App Store Connect, and the remote Android version code is initialized from the current app config.
 - Internal testers belong to an automatically distributed TestFlight group. External testers have completed Apple's required Beta App Review.
 
 ## Release
@@ -34,6 +34,7 @@ Submission stops at TestFlight. Releasing the build publicly still requires manu
 - `eas.json` parses as JSON.
 - Expo resolves bundle identifier `com.devmood.pixymoodtracker`, EAS project ID `8917be91-f1cc-4276-a252-674a28490ac3`, and App Store Connect app ID `1605327124`.
 - Production profile uses remote versioning and automatic build-number increments.
+- Remote versions are initialized for both iOS and Android.
 - Test and type-check workflows pass.
 - GitHub Actions secret `EXPO_TOKEN` exists.
 - EAS iOS distribution and App Store Connect credentials are valid.
@@ -59,9 +60,11 @@ Submission stops at TestFlight. Releasing the build publicly still requires manu
 ### Failure behavior
 
 - Missing or invalid Expo authentication fails before a build starts.
-- Missing, expired, or changed Apple credentials fail the build because CI uses `--freeze-credentials`; CI never replaces credentials silently.
+- Missing, expired, or changed Apple build credentials fail the build because CI uses `--freeze-credentials`; CI never replaces build credentials silently.
+- Missing or invalid App Store Connect credentials fail the submission after a successful build.
 - Build or submission failure is visible from the EAS build/submission linked by GitHub Actions.
-- Retrying the release build uses a new remote build number and does not collide with an earlier upload.
+- Retry a failed submission without rebuilding: `eas submit --platform ios --profile production --id <BUILD_ID>`.
+- Retrying a failed build creates a new remote build number and does not collide with an earlier upload.
 
 ## Rollback
 

--- a/eas.json
+++ b/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 16.0.0",
-    "appVersionSource": "local"
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {
@@ -20,10 +20,15 @@
       }
     },
     "production": {
-      "channel": "production"
+      "channel": "production",
+      "autoIncrement": true
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ios": {
+        "ascAppId": "1605327124"
+      }
+    }
   }
 }


### PR DESCRIPTION
## What changed

- Trigger one EAS production iOS build only when Release Please creates a GitHub release.
- Auto-submit successful builds to TestFlight without submitting them for public App Review.
- Use EAS remote build-number management with automatic increments.
- Configure App Store Connect app `1605327124` for production submissions.
- Document prerequisites, release operation, rollback, and reviewable verification criteria.
- Mark the repository as public OSS and prohibit credentials in code, GitHub text, logs, and artifacts.

## Why

Current `preview` profile creates internally distributed ad hoc builds, not TestFlight builds. Current Release Please workflow creates releases but does not build or submit iOS binaries.

This change connects final Release Please merges to EAS Build and EAS Submit while retaining manual control over public App Store releases.

## Verification

- [x] `eas.json` parses as JSON.
- [x] Expo config resolves expected bundle identifier and EAS project ID.
- [x] GitHub workflow passes `actionlint`.
- [x] TypeScript passes.
- [x] 65 tests pass; 12 existing tests remain skipped.
- [x] GitHub `EXPO_TOKEN` secret exists.
- [x] Expo browser login completed; access to `@z49/pixy-mood-tracker` verified.
- [x] Remote iOS build number initialized to `1.86.0`.
- [ ] EAS Apple distribution and App Store Connect credentials verified.
- [ ] Confirm `1.86.0` exceeds the highest build already uploaded to App Store Connect.
- [ ] First Release Please merge creates one production build visible in TestFlight.
- [ ] Intended TestFlight users can install that build.

Full criteria: [`docs/testflight-release-workflow.md`](https://github.com/mrzmyr/pixy-mood-tracker-app/blob/agent/testflight-release-workflow/docs/testflight-release-workflow.md)

## Merge gate

This adoption PR may merge after review and CI because it does not create a GitHub release or TestFlight build. Complete the remaining Apple credential checks before merging the next Release Please PR, which exercises the release path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated iOS production builds and TestFlight submissions after successful releases.
  - Enabled automatic production version increments and remote version management.
  - Configured App Store Connect submission for iOS releases.

- **Documentation**
  - Added TestFlight release, verification, failure recovery, and rollback guidance.
  - Updated release instructions for iOS, Android, and compatible over-the-air updates.
  - Added guidance for securely handling release credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->