### PR TITLE
docs: document physical iOS test runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,12 @@
 - Never expose credentials, secrets, or personal data in evidence.
 - If evidence cannot be produced, keep the pull request in draft, document the blocker, and get explicit human approval before merging.
 
+## Physical iOS end-to-end tests
+
+- Use [`maestro-runner`](https://github.com/devicelab-dev/maestro-runner) for physical iPhone end-to-end tests. Use direct XCUITest only when the runner cannot express the behavior.
+- Test installed TestFlight builds with `--no-app-install`; never use `clearState` because it can remove tester data.
+- Keep device and signing-team identifiers local. Attach generated artifacts to the pull request.
+
 ## Errors
 
 - Every error created, thrown, returned, or logged must expose `status`, `message`, `why`, and `fix`.


### PR DESCRIPTION
## Why

Use the validated physical-iPhone runner consistently.

## Change

- Use `maestro-runner` for physical iPhone end-to-end tests.
- Keep XCUITest as the fallback.
- Protect TestFlight data with `--no-app-install` and no `clearState`.
- Keep device and signing identifiers local.
- Attach generated artifacts to the pull request.

## Validation

`maestro-runner` 1.1.21 successfully drove the installed TestFlight build on a physical iPhone. The smoke run passed 9/9 commands in 39 seconds and reported `isSimulator: false`.

`git diff --check` passes. The PR changes only `AGENTS.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for running physical iOS end-to-end tests.
  * Documented recommended testing workflows, including TestFlight validation and artifact sharing.
  * Clarified practices for preserving device state and keeping local identifiers private.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->