### PR TITLE
docs: keep pull request proof out of repository

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@
 ## Pull request proof
 
 - Every agent-authored pull request must prove to the human reviewer that the change works before it is marked ready or merged.
-- Include screenshots or a video in the pull request body that show the successful result. For non-visual changes, show the relevant observable behavior or test execution.
+- Attach screenshots or a video directly to the pull request body or a pull request comment. For non-visual changes, show the relevant observable behavior or test execution.
+- Never commit proof-only screenshots, videos, or evidence files to the repository. Commit a visual file only when it is a product or documentation asset needed independently of the pull request.
 - Show before and after evidence when behavior or UI is changed or removed.
 - Document the environment and exact steps used to produce the evidence so the reviewer can reproduce it.
 - Document the edge cases checked, including each expected result and actual result. Cover failure, empty, loading, boundary, and regression states when relevant.


### PR DESCRIPTION
## Why

Pull request proof belongs with the review, not in the product repository.

## What changed

- Require screenshots or videos to be attached directly to the pull request body or a comment.
- Prohibit committing proof-only evidence files.
- Allow committed visuals only when they are real product or documentation assets.

## Validation

- `git diff --check` passes.
- The change affects only `AGENTS.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request proof guidance to require screenshots or videos in the pull request or comments.
  * Clarified that proof-only media and evidence files should not be committed to the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->