### PR TITLE
docs(agents): add PR asset proof skill

### DIFF
--- a/.agents/skills/attach-pr-asset/SKILL.md
+++ b/.agents/skills/attach-pr-asset/SKILL.md
@@ -12,7 +12,7 @@ description: Attach screenshot or video proof to a GitHub pull request without c
 PR_NUMBER="${PR_NUMBER:-$(gh pr view --json number --jq '.number')}"
 REPO="${REPO:-$(gh repo view --json nameWithOwner --jq '.nameWithOwner')}"
 HEAD_SHA="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq '.headRefOid')"
-TAG="pr-${PR_NUMBER}-assets"
+TAG="pr-${PR_NUMBER}-assets-${HEAD_SHA:0:12}"
 ```
 
 3. Create a public prerelease targeting PR head, then upload evidence files:
@@ -38,20 +38,20 @@ gh api "repos/$REPO/releases/tags/$TAG" \
   --jq '.assets[] | [.name, .browser_download_url] | @tsv'
 ```
 
-5. Preserve existing PR body. Append `## Visual proof` using `gh pr edit --body-file`:
+5. Preserve existing PR body. Append `## Visual proof`, then update using `--body-file`:
 
-```markdown
-## Visual proof
+```bash
+BODY_FILE="$(mktemp)"
+gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body' > "$BODY_FILE"
 
-### Before
+{
+  printf '\n\n## Visual proof\n\n'
+  printf '### Before\n\n![Before](%s)\n\n' "$BEFORE_URL"
+  printf '### After\n\n![After](%s)\n\n' "$AFTER_URL"
+  printf '[Watch video](%s)\n' "$VIDEO_URL"
+} >> "$BODY_FILE"
 
-![Before](BEFORE_URL)
-
-### After
-
-![After](AFTER_URL)
-
-[Watch video](VIDEO_URL)
+gh pr edit "$PR_NUMBER" --repo "$REPO" --body-file "$BODY_FILE"
 ```
 
 Include environment, reproduction steps, expected result, actual result, and relevant edge cases. Omit missing asset types.

--- a/.agents/skills/attach-pr-asset/SKILL.md
+++ b/.agents/skills/attach-pr-asset/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: attach-pr-asset
+description: Attach screenshot or video proof to a GitHub pull request without committing evidence files. Use when an agent-authored PR needs before-and-after images, recordings, or other visual proof in its body or comments.
+---
+
+# Attach PR Asset
+
+1. Confirm every asset exists and contains no credentials, secrets, or personal data.
+2. Resolve PR, repository, and PR head SHA:
+
+```bash
+PR_NUMBER="${PR_NUMBER:-$(gh pr view --json number --jq '.number')}"
+REPO="${REPO:-$(gh repo view --json nameWithOwner --jq '.nameWithOwner')}"
+HEAD_SHA="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq '.headRefOid')"
+TAG="pr-${PR_NUMBER}-assets"
+```
+
+3. Create a public prerelease targeting PR head, then upload evidence files:
+
+```bash
+ASSETS=(/tmp/before.png /tmp/after.png) # May include .mp4 or .mov files.
+
+gh release create "$TAG" "${ASSETS[@]}" \
+  --repo "$REPO" \
+  --target "$HEAD_SHA" \
+  --title "PR #${PR_NUMBER} assets" \
+  --notes "Visual evidence for PR #${PR_NUMBER}." \
+  --prerelease \
+  --latest=false
+```
+
+If release already exists, use `gh release upload "$TAG" <files...> --repo "$REPO"`. Replace an existing asset only after confirming exact target.
+
+4. Read each asset's `browser_download_url`:
+
+```bash
+gh api "repos/$REPO/releases/tags/$TAG" \
+  --jq '.assets[] | [.name, .browser_download_url] | @tsv'
+```
+
+5. Preserve existing PR body. Append `## Visual proof` using `gh pr edit --body-file`:
+
+```markdown
+## Visual proof
+
+### Before
+
+![Before](BEFORE_URL)
+
+### After
+
+![After](AFTER_URL)
+
+[Watch video](VIDEO_URL)
+```
+
+Include environment, reproduction steps, expected result, actual result, and relevant edge cases. Omit missing asset types.
+
+6. Verify links from signed-out/public context. Keep PR draft if proof is missing or inaccessible.
+
+Never commit proof-only assets. Never overwrite existing PR body. Never delete PR asset release while PR depends on it.

--- a/.agents/skills/attach-pr-asset/agents/openai.yaml
+++ b/.agents/skills/attach-pr-asset/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Attach PR Asset"
+  short_description: "Upload visual proof without committing files"
+  default_prompt: "Use $attach-pr-asset to attach screenshot or video proof to the current pull request."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 
 - Every agent-authored pull request must prove to the human reviewer that the change works before it is marked ready or merged.
 - Attach screenshots or a video directly to the pull request body or a pull request comment. For non-visual changes, show the relevant observable behavior or test execution.
+- Use [`attach-pr-asset`](.agents/skills/attach-pr-asset/SKILL.md) to upload screenshot or video proof without committing evidence files.
 - Never commit proof-only screenshots, videos, or evidence files to the repository. Commit a visual file only when it is a product or documentation asset needed independently of the pull request.
 - Show before and after evidence when behavior or UI is changed or removed.
 - Document the environment and exact steps used to produce the evidence so the reviewer can reproduce it.


### PR DESCRIPTION
## Summary

- Add repo-local `attach-pr-asset` skill for screenshot and video evidence.
- Link workflow from `AGENTS.md`.
- Keep proof assets out of repository history by publishing them as PR-scoped prerelease assets.
- Preserve existing PR body when appending evidence.

## Why

Agent-authored PRs require reproducible proof, but repository guidance did not provide an automated attachment path. This adds one small, reusable workflow.

## Observable proof

Environment: macOS, project worktree based on `origin/main`.

```text
$ quick_validate.py .agents/skills/attach-pr-asset
Skill is valid!

$ git diff --check
# no output; passed
```

## Reproduction

1. Open `.agents/skills/attach-pr-asset/SKILL.md`.
2. Confirm skill resolves current PR, repository, and PR head SHA.
3. Confirm screenshots and videos upload to `pr-<number>-assets`.
4. Confirm instructions require preserving existing PR body.
5. Confirm `AGENTS.md` links directly to skill.

## Edge cases

| State | Expected | Actual |
| --- | --- | --- |
| Screenshot proof | Embed image URL | Documented |
| Video proof | Link release asset | Documented |
| Existing asset release | Upload to existing release | Documented |
| Existing PR body | Preserve before appending | Required |
| Secret or personal data | Reject before upload | Required |
| Missing/inaccessible proof | Keep PR draft | Required |

No credentials, personal data, or proof-only assets are committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for attaching screenshot and video evidence to pull requests without committing asset files.
  * Documented asset validation, public accessibility checks, and safe handling of existing pull request content and releases.
  * Added agent metadata and usage instructions for the new attachment workflow.
  * Clarified how to handle unavailable or inaccessible evidence while preserving drafts and existing release content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->