### PR TITLE
docs(agents): keep PR screenshots compact

### DIFF
--- a/.agents/skills/attach-pr-asset/SKILL.md
+++ b/.agents/skills/attach-pr-asset/SKILL.md
@@ -46,15 +46,17 @@ gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body' > "$BODY_FILE"
 
 {
   printf '\n\n## Visual proof\n\n'
-  printf '### Before\n\n![Before](%s)\n\n' "$BEFORE_URL"
-  printf '### After\n\n![After](%s)\n\n' "$AFTER_URL"
+  printf '<table>\n<tr>\n'
+  printf '<td width="50%%"><strong>Before</strong><br><img src="%s" alt="Before" width="100%%"></td>\n' "$BEFORE_URL"
+  printf '<td width="50%%"><strong>After</strong><br><img src="%s" alt="After" width="100%%"></td>\n' "$AFTER_URL"
+  printf '</tr>\n</table>\n\n'
   printf '[Watch video](%s)\n' "$VIDEO_URL"
 } >> "$BODY_FILE"
 
 gh pr edit "$PR_NUMBER" --repo "$REPO" --body-file "$BODY_FILE"
 ```
 
-Include environment, reproduction steps, expected result, actual result, and relevant edge cases. Omit missing asset types.
+Present two or more screenshots in a two-column grid. Put before and after screenshots side by side. Include environment, reproduction steps, expected result, actual result, and relevant edge cases. Omit missing asset types.
 
 6. Verify links from signed-out/public context. Keep PR draft if proof is missing or inaccessible.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 - Use [`attach-pr-asset`](.agents/skills/attach-pr-asset/SKILL.md) to upload screenshot or video proof without committing evidence files.
 - Never commit proof-only screenshots, videos, or evidence files to the repository. Commit a visual file only when it is a product or documentation asset needed independently of the pull request.
 - Show before and after evidence when behavior or UI is changed or removed.
+- Present two or more screenshots in a two-column grid in the pull request body or comment so they remain reviewable at normal viewport sizes. Put before and after screenshots side by side.
 - Document the environment and exact steps used to produce the evidence so the reviewer can reproduce it.
 - Document the edge cases checked, including each expected result and actual result. Cover failure, empty, loading, boundary, and regression states when relevant.
 - Never expose credentials, secrets, or personal data in evidence.


### PR DESCRIPTION
## Summary

- Require two-column layout when PR proof contains multiple screenshots.
- Update `attach-pr-asset` template to place before/after screenshots side by side.

## Why

Stacked phone screenshots render too large and make comparison slow. Two columns keep both states visible at normal viewport sizes.

## Validation

- `quick_validate.py .agents/skills/attach-pr-asset` — passed
- `git diff --check` — passed
- GitHub rendered HTML for PR #246 preserves two 50% table cells and both images.

## Visual proof

Environment: GitHub PR Markdown, source screenshots from iOS 26.3 simulator (`Pixy UI Audit`).

![Two-column before and after proof](https://github.com/mrzmyr/pixy-mood-tracker-app/releases/download/pr-248-assets-d0cd8fc6fe14/pr-proof-two-column.png)

**Expected:** Before and after phone screenshots appear side by side at reviewable size.

**Actual:** Both full-height states fit in one compact 900 × 978 comparison.

### Reproduce

1. Add two screenshot assets to a PR body using the updated skill template.
2. Confirm GitHub renders two 50% table cells.
3. Confirm before and after remain visible side by side.

### Edge cases

| State | Expected | Actual |
| --- | --- | --- |
| One screenshot | No grid required | Guidance applies only to two or more |
| Two screenshots | One two-column row | Covered; passed |
| Before/after pair | Same row | Covered; passed |
| Video proof | Remains a link | Template unchanged |