### PR TITLE
fix(deps): revert @react-navigation/native-stack to v6 to match native v6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@react-native-community/hooks": "^2.8.1",
         "@react-navigation/bottom-tabs": "^6.3.1",
         "@react-navigation/native": "^6.0.2",
-        "@react-navigation/native-stack": "^7.18.6",
+        "@react-navigation/native-stack": "^6.9.7",
         "@sentry/react-native": "~7.11.0",
         "buffer": "^6.0.3",
         "chroma-js": "^3.2.0",
@@ -471,7 +471,7 @@
 
     "@react-navigation/native": ["@react-navigation/native@6.1.18", "", { "dependencies": { "@react-navigation/core": "^6.4.17", "escape-string-regexp": "^4.0.0", "fast-deep-equal": "^3.1.3", "nanoid": "^3.1.23" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-mIT9MiL/vMm4eirLcmw2h6h/Nm5FICtnYSdohq4vTLA2FF/6PNhByM7s8ffqoVfE5L0uAa6Xda1B7oddolUiGg=="],
 
-    "@react-navigation/native-stack": ["@react-navigation/native-stack@7.18.6", "", { "dependencies": { "@react-navigation/elements": "^2.9.36", "color": "^4.2.3", "sf-symbols-typescript": "^2.1.0", "warn-once": "^0.1.1" }, "peerDependencies": { "@react-navigation/native": "^7.3.14", "react": ">= 18.2.0", "react-native": "*", "react-native-safe-area-context": ">= 4.0.0", "react-native-screens": ">= 4.0.0" } }, "sha512-KuvvSBddHrbKC4c6yKz+UCFey2xgTuPQHgjf2wJQAvA7JM8jCQa3G1+QzhO6d44nYNKir3y6EounXZvQE/BX6w=="],
+    "@react-navigation/native-stack": ["@react-navigation/native-stack@6.11.0", "", { "dependencies": { "@react-navigation/elements": "^1.3.31", "warn-once": "^0.1.0" }, "peerDependencies": { "@react-navigation/native": "^6.0.0", "react": "*", "react-native": "*", "react-native-safe-area-context": ">= 3.0.0", "react-native-screens": ">= 3.0.0" } }, "sha512-U5EcUB9Q2NQspCFwYGGNJm0h6wBCOv7T30QjndmvlawLkNt7S7KWbpWyxS9XBHSIKF57RgWjfxuJNTgTstpXxw=="],
 
     "@react-navigation/routers": ["@react-navigation/routers@6.1.9", "", { "dependencies": { "nanoid": "^3.1.23" } }, "sha512-lTM8gSFHSfkJvQkxacGM6VJtBt61ip2XO54aNfswD+KMw6eeZ4oehl7m0me3CR9hnDE4+60iAZR8sAhvCiI3NA=="],
 
@@ -1573,8 +1573,6 @@
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
-    "sf-symbols-typescript": ["sf-symbols-typescript@2.2.0", "", {}, "sha512-TPbeg0b7ylrswdGCji8FRGFAKuqbpQlLbL8SOle3j1iHSs5Ob5mhvMAxWN2UItOjgALAB5Zp3fmMfj8mbWvXKw=="],
-
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
@@ -1864,8 +1862,6 @@
     "@jest/types/@jest/schemas": ["@jest/schemas@29.6.3", "", { "dependencies": { "@sinclair/typebox": "^0.27.8" } }, "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA=="],
 
     "@react-navigation/core/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
-
-    "@react-navigation/native-stack/@react-navigation/elements": ["@react-navigation/elements@2.9.36", "", { "dependencies": { "color": "^4.2.3", "use-latest-callback": "^0.2.4", "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "@react-native-masked-view/masked-view": ">= 0.2.0", "@react-navigation/native": "^7.3.14", "react": ">= 18.2.0", "react-native": "*", "react-native-safe-area-context": ">= 4.0.0" }, "optionalPeers": ["@react-native-masked-view/masked-view"] }, "sha512-+10x9s5v2Q7FwAYdSmPMgILtxZyC5e4hWJQu8g5o3u4p8DUToTBmGvys/UvmEr+h9xmm0Go42qw9Ff2ape53kQ=="],
 
     "@sentry/cli/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@react-native-community/hooks": "^2.8.1",
     "@react-navigation/bottom-tabs": "^6.3.1",
     "@react-navigation/native": "^6.0.2",
-    "@react-navigation/native-stack": "^7.18.6",
+    "@react-navigation/native-stack": "^6.9.7",
     "@sentry/react-native": "~7.11.0",
     "buffer": "^6.0.3",
     "chroma-js": "^3.2.0",


### PR DESCRIPTION
## Summary
- v1.87.0 crashes on **every launch** in TestFlight (build 1.86.3) — confirmed via `eas testflight:crashes` and reproduced locally on simulator.
- Root cause: a Dependabot PR bundled into that release bumped `@react-navigation/native-stack` 6.11.0 → 7.18.6, but `@react-navigation/native` was left on `^6.0.2`. native-stack v7 requires native `^7.3.14` as a peer and calls its v7-only `createScreenFactory` export at module-evaluation time — undefined on v6, so it throws `TypeError: undefined is not a function` before the JS runtime is ready, tripping Expo's `ErrorRecovery` safety net and hard-crashing (SIGABRT).
- Not related to the Support Pixy / Superwall feature also in this release — verified by disabling that provider entirely and confirming the identical crash still occurred, then bisecting to this dependency.
- Fix: revert `native-stack` to `^6.9.7` (resolves to 6.11.0, its pre-bump version), matching the installed `native` v6. Minimal, verified fix — not a v7 migration.

## Test plan
- [x] Reproduced the exact crash locally (Debug build on iOS Simulator, real Superwall API keys pulled from EAS production env) — confirmed via readable stack trace pointing at `_reactNavigationNative.createScreenFactory`.
- [x] Confirmed `createScreenFactory` does not exist in the installed `@react-navigation/native@6.1.18`, only in v7.
- [x] Applied this revert, reinstalled, rebuilt, reran on simulator — app boots into its real UI, no crash.
- [ ] After merge, verify the resulting release build lands cleanly in TestFlight (no crash on open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the navigation package version to improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->